### PR TITLE
Added reference to Suave.Http.RequestErrors

### DIFF
--- a/query_parameters.md
+++ b/query_parameters.md
@@ -17,13 +17,13 @@ A function which takes as an argument another function is often called "Higher o
 `r` in our lambda represents the `HttpRequest`. It has a `queryParam` member function of type 
 `string -> Choice<string,string>`. `Choice` is a type that represents a choice between two types.
 Usually you'll find that the first type of `Choice` is for happy paths, while second means something went wrong.
-In our case first string stands for a value of the query parameter, and the second string stands for error message (paramater with given key was not found in query).
+In our case the first string stands for a value of the query parameter, and the second string stands for error message (parameter with given key was not found in query).
 We can make use of pattern matching to distinguish between two possible choices.
 Pattern matching is yet another really powerful feature, implemented in variety of modern programming languages. 
 For now we can think of it as a switch statement with binding value to an identifier in one go.
 In addition to that, F# compiler will issue an warning in case we don't provide all possible cases (`Choice1Of2 x` and `Choice2Of2 x` here).
 There's actually much more for pattern matching than that, as we'll discover later.
-`BAS_REQUEST` is a function from Suave library, and it returns WebPart with 400 Bad Request status code response with given message in its body.
+`BAD_REQUEST` is a function from Suave library (you may need to open `Suave.Http.RequestErrors`), and it returns WebPart with 400 Bad Request status code response with given message in its body.
 We can summarize the `browse` WebPart as following:
 If there is a "genre" parameter in the url query, return 200 OK with the value of the "genre", otherwise return 400 Bad Request with error message.
 


### PR DESCRIPTION
Added reference to Suave.Http.RequestErrors that I found was not already opened from the tutorial page, might cause others a little difficulty. Also corrected some typos I noticed, I may have missed others though.
