### PR TITLE
Updated syntax for `DbContext`

### DIFF
--- a/en/database.md
+++ b/en/database.md
@@ -48,9 +48,9 @@ The generated types have a bit cumbersome names, but we can define type aliases 
 
 ```fsharp
 type DbContext = Sql.dataContext
-type Album = DbContext.``[dbo].[Albums]Entity``
-type Genre = DbContext.``[dbo].[Genres]Entity``
-type AlbumDetails = DbContext.``[dbo].[AlbumDetails]Entity``
+type Album = DbContext.``dbo.AlbumsEntity``
+type Genre = DbContext.``dbo.GenresEntity``
+type AlbumDetails = DbContext.``dbo.AlbumDetailsEntity``
 ```
 
 `DbContext` is our data context.

--- a/en/queries.md
+++ b/en/queries.md
@@ -5,30 +5,31 @@ With the type aliases set up, we can move forward to creating our first queries:
 ```fsharp
 let firstOrNone s = s |> Seq.tryFind (fun _ -> true)
 
-let getGenres (ctx : DbContext) : Genre list = 
-    ctx.``[dbo].[Genres]`` |> Seq.toList
+let getGenres (ctx : DbContext) : Genre list =
+    ctx.Dbo.Genres |> Seq.toList
 
-let getAlbumsForGenre genreName (ctx : DbContext) : Album list = 
-    query { 
-        for album in ctx.``[dbo].[Albums]`` do
-            join genre in ctx.``[dbo].[Genres]`` on (album.GenreId = genre.GenreId)
-            where (genre.Name = genreName)
-            select album
-    }
-    |> Seq.toList
+let getAlbumsForGenre genreName (ctx : DbContext) : Album list =
+        query {
+            for album in ctx.Dbo.Albums do
+                join genre in ctx.Dbo.Genres on (album.GenreId = genre.GenreId)
+                where (genre.Name = genreName)
+                select album
+        }
+        |> Seq.toList
 
-let getAlbumDetails id (ctx : DbContext) : AlbumDetails option = 
-    query { 
-        for album in ctx.``[dbo].[AlbumDetails]`` do
-            where (album.AlbumId = id)
-            select album
-    } |> firstOrNone
+let getAlbumDetails id (ctx : DbContext) : AlbumDetails option =
+        query{
+            for album in ctx.Dbo.AlbumDetails do
+                where (album.AlbumId = id)
+                select album
+        }
+        |> firstOrNone
 ```
 
 `getGenres` is a function for finding all genres. 
 The function, as well as all functions we'll define in `Db` module, takes the `DbContext` as a parameter.
 The `: Genre list` part is a type annotation, which makes sure the function returns a list of `Genre`s.
-Implementation is straight forward:  ```ctx.``[dbo].[Genres]`` ``` queries all genres, so we just need to pipe it to the `Seq.toList`.
+Implementation is straight forward:  ```ctx.Dbo.Genres`` ``` queries all genres, so we just need to pipe it to the `Seq.toList`.
 
 `getAlbumsForGenre` takes `genreName` as argument (inferred to be of type string) and returns a list of `Album`s.
 It makes use of "query expression" (`query { }`) which is very similar to C# Linq query.


### PR DESCRIPTION
The syntax used didn't work when using brackets and created errors such as:

>Error FS0039: The field, constructor or member '[dbo].[Albums]' is not defined. (25, 30)

The updated syntax (`ctx.Dbo.Albums`) works fine and even allows for autocompletion (in IDEs that support it of course).

Sorry about the slightly inaccurate commit message. I'm a bit lazy today and used the web interface to make my edits.